### PR TITLE
Don't throw errors for not-implemented functions. Fixes #4.

### DIFF
--- a/lib/controller_server.js
+++ b/lib/controller_server.js
@@ -2,10 +2,10 @@ Controller.prototype.init = function () {};
 
 // futures somehow. but not clear exactly what this means.
 Controller.prototype.wait = function () {
-  throw new Error('Not implemented on server yet.');
+  console.warn('controller.wait() is not implemented on server yet. Please ensure you are running this only from the client.');
 };
 
 // is future ready?
 Controller.prototype.ready = function () {
-  throw new Error('Not implemented on server yet.');
+  console.warn('controller.ready() is not implemented on server yet. Please ensure you are running this only from the client.');
 };


### PR DESCRIPTION
Because of the usual configuration pattern for IronRouter, it's easy to mistakenly run call `.wait()` from the server side. This occurs when subscriptions are defined for _both_ client and server via `this.subscribe(..).wait()`.
