### PR TITLE
Replace not implemented functions with noop. Fixes #4

### DIFF
--- a/lib/controller_server.js
+++ b/lib/controller_server.js
@@ -1,11 +1,7 @@
 Controller.prototype.init = function () {};
 
 // futures somehow. but not clear exactly what this means.
-Controller.prototype.wait = function () {
-  throw new Error('Not implemented on server yet.');
-};
+Controller.prototype.wait = function () {};
 
 // is future ready?
-Controller.prototype.ready = function () {
-  throw new Error('Not implemented on server yet.');
-};
+Controller.prototype.ready = function () {};


### PR DESCRIPTION
iron:router users are encouraged to implement all routes on client and server (see [README.md](https://github.com/EventedMind/iron-router/blob/f80d2b5c9bf3b680aeb5974d430884804015cbe7/README.md#routes-on-client-and-server) and [#944](/EventedMind/iron-router/issues/944)). This results in errors when any of the client side routes use `.wait` or `.ready`. This pull request removes those errors for now.
