### PR TITLE
Changed .forEach to _.each for IE8 compatibility 

### DIFF
--- a/lib/wait_list.js
+++ b/lib/wait_list.js
@@ -40,7 +40,7 @@ var assertNoInvalidationLoop = function (dependency) {
   var parentComps = parentComputations();
   var depCompIds = _.keys(dependency._dependentsById);
 
-  depCompIds.forEach(function (id) {
+  _.each(depCompIds, function (id) {
     assert(!parentComps[id], "\n\n\
 You called wait() after calling ready() inside the same computation tree.\
 \n\n\


### PR DESCRIPTION
.forEach breaks iron-controller in IE8 as the browser doesn't support it. Using underscorejs instead seems like a simple fix!

First pull-request so hope this is useful / I've done it right.

Thanks.